### PR TITLE
Add landing page for Barcelona chapter draft in Spanish

### DIFF
--- a/page_assets/landing-page.md
+++ b/page_assets/landing-page.md
@@ -1,0 +1,21 @@
+[CAT] Versió en català més endavant
+[EN] English version below
+
+[ES]
+Hola, bienvenid@ al capítulo de Barcelona de codebar.io. Si has llegado aquí seguramente sea porque te interesa la programación y estas buscando coraje para dar los primeros pasos en un espacio seguro y colaborativo; o quizás, ya has comenzado, pero necesitas ayuda para seguir adelante. Alumnos, mentores y organizadores estamos aquí para ayudarte con esto.
+
+Tienes dudas? La sección de Preguntas Frecuentes al pie de esta página (FAQ) puede darte la información que buscas. Ignora las partes especificas de Londres, todo lo demás aplica de igual modo aquí en Barcelona. Aun tienes dudas, escríbenos a barcelona@codebar.io o apúntate en el canal #barcelona-chapter de nuestra comunidad Slack entrando en slack.codebar.io.
+
+Ya estas list@, suscríbete para recibir las invitaciones a los próximos eventos (Busca el boton de 'Sign up' aqui abajo). No olvides apuntarte al evento que quieres asistir luego de suscribirte. Podrás ver los próximos eventos aquí abajo.
+
+Quieres ser mentor/a? Cuando te suscribas hazlo como coach! Dicen que la mejor forma de aprender es enseñando. Ayúdanos a demostrar que es cierto, ven a alguno de nuestros próximos encuentros. Si lo necesitas, nosotros te ayudaremos!
+
+[EN]
+{To be completed by a collaborator}
+
+[CAT]
+{Per ser completat per un col·laborador}
+
+
+-----
+Once text is agreed it can be uploaded from https://codebar.io/admin/chapters/15/edit. To be checked: is the Max 280 characters limitation still active?


### PR DESCRIPTION
After some enlightening with @daverick, I deleted the draft previously pushed to master and committed it again (no changes) as a PR so we can build it up together. 
cc: @amaliacardenas @loriking @yashamuru @daverick @irina 

For now it's just Spanish. My idea was that we ask the BCN members to help with the translations in a collaborative way once the ES is agreed.

What do you think? The idea is that this text is shown when entering to https://codebar.io/barcelona
