### PR TITLE
Add collaborators board

### DIFF
--- a/processes/initiatives/collaborators-board/collaborations.md
+++ b/processes/initiatives/collaborators-board/collaborations.md
@@ -1,0 +1,48 @@
+# Collaborators board
+
+## Objective
+The codebar.io community is growing and also are the wishes to contribute to this project. For this reason, we would like to start sharing some of the organisers activities with the growing community.
+
+So, when you are ready to take you collaboration to the next level, we have a bunch of tasks that you can help us with. **Ready?**
+
+## How to contribute
+Start by reading the options below, we separated them in **During the workshops** and in **Between workshops**. If you want to perform any of them, let us know on Slack. The text below are just short descriptions. In case you are in to try any of them, we'll explain more in details. Taking one of this tasks does not mean you'll do it for live. You can take any of them only once, or regularly. It's up to your availability.
+
+## During the workshops
+### Preparing the space
+This task consists in arriving a bit earlier than the _workshop_ start time to **help the company hosting us** prepare the space. Set up tables and electricity extenders, spread the food and drinks, set up the reception desk, and sometimes receive some early comers. The hosts, specially the new ones, are intrigued by the way everything will work and they want to give the best of them. This task also has a bounding part with the host and a part of giving back some help to them.
+
+### Door person
+This task consists in **receiving the participants** while they arrive. Checking-in the students and coaches using codebar platform, giving a name tag and briefly introducing them to the space (where the food, bathrooms, etc are). For new comers, this person can put her/him in contact to someone helping in the integration (see the next activity for details).
+
+### Integrating new-comers
+This task is very important and can be _life changer_ in the experience the participants will take out of codebar. It consists in having an eye on the people coming to codebar for the first time. **There are quite _outgoing_ people that will not need help integrating with others**, but there also more _introvert_ people that will need some extra help. Persons taking this task should be going around the space making sure that there is no-one left alone, and after a short talk try putting them in contact with some other regulars. Asking what they want to learn/coach can help putting them in contact already with students/coaches sharing that interest.
+
+### Introducing codebar - MC
+We normally call this role the MC (Master of Ceremony). This person is the one that **starts the workshops** by setting up a circle, explaining what we'll do and the main rules. Also thanks everyone for collaborating. More details of what should be said during the presentation can be found [here](../../workshops-preparation/script-presentation.md).
+
+### Pairing support
+Pairing has improved a lot with the introduction of an online tool built for this task. Nevertheless, using this tool has still some manual work **to find the best Student-Coach pairs**. A good pairing makes codebar experience memorable for both students and coaches.
+
+Sometimes, pairing is not an easy task and it has to be performed quite quickly (we only have the time during the presentations to come up with a list of pairs). This task also has some researching part where the person doing it should ask the students **what they want to learn** and the coaches **what they can teach**. This is normally performed in the first segment while people is eating /drinking.
+
+## Between workshops
+### In Slack
+Slack is part of building the community. There are two channels specific for Barcelona: #barcelona-chapter and #barcelona-social. This task consists in **participating and moderating** these channels based on the mission of codebar.io. It also consists in reminding of upcoming sessions, our social media, etc regularly.
+
+### In our social media
+We have [MeetUp](https://www.meetup.com/codebar-Barcelona/), [Instagram](https://www.instagram.com/codebarbcn/), [Twitter](https://twitter.com/codebarbcn) and [Facebook](https://www.facebook.com/codebarBCN) accounts. This task consists in helping creating content in one (or as many as you want) platforms. They are currently only used for promoting the workshops, but nothing forbids us to **publish more content related to codebar mission** in between them.
+
+### Looking for new hosts
+The more we grow, the more we need hosts big enough to host us. This tasks consists in helping **finding new companies that can host us**. Normally, codebar members refer us the companies where they work. After that, this task consists in reaching them out, explaining what codebar is, if possible visit them to confirm that the space is adequate, and follow up with the contact person on the preparation. They normally have questions and having someone at hand from the codebar organisation is always part of the nice ramp up process for them.
+[This article](../../host-selection/host-prioritization.md) defines the **must** and **nice to have** for new hosts and additional information about this task.
+
+### Contributing to our on-going initiatives
+We keep all our initiatives public in Github so anyone can comment on them. The more diverse the people that reviews them is, the better they will result. So don't be afraid to **check the [open initiatives board](https://github.com/codebar/barcelona/projects/2) and leave you comments** at any of them.
+
+Below is a few of them where more active participation is welcome:
+#### Pairing support tool
+It consists in building a **new tool to help in the pairing process**. More info: [here](../../../tools/pairing-support-tool/README.md)
+
+#### One-off workshops
+It consists in giving **topic-specific talks in between workshops**. These talks will have a different format and will be given in specific days. Most probably once a month. If you have a talk that you'll like to present get in touch with us. More info: [here](https://github.com/codebar/barcelona/projects/1)

--- a/processes/initiatives/collaborators-board/open-point.md
+++ b/processes/initiatives/collaborators-board/open-point.md
@@ -1,0 +1,3 @@
+
+* Slack is an easy way to reach to, but will not generate visibility in the community
+* Review/update links when the referred articles are merged to master.


### PR DESCRIPTION
Hi Barcelona team,

Following the initiative #53, please find in this PR an initial version of the collaborators board. This page describes mainly everything we do (in a very short form) so we can easily share to our community. 

Please comment :) It would be nice to have it merged before next monthly so we can give the green light to announce it during the meeting.