### PR TITLE
Longer workshop 

### DIFF
--- a/processes/initiatives/longer-workshops_VTO/Event-Description.md
+++ b/processes/initiatives/longer-workshops_VTO/Event-Description.md
@@ -1,0 +1,15 @@
+# Event description
+
+A special codebar workshop that last 4 hours on a Friday afternoon. So that student get a better and stronger learning experience.
+
+Same  codebar workshop format:
+* socialization
+* round of presentation ( silly question included!)
+* 1 o 1
+
+Governed by the same [code of conduct](https://codebar.io/code-of-conduct)
+
+Plus some specifics:
+* a coffee break with talks
+* a short final presentation from each student
+* student and coaches are paired in advance and have meet (online) before

--- a/processes/initiatives/longer-workshops_VTO/README.md
+++ b/processes/initiatives/longer-workshops_VTO/README.md
@@ -1,0 +1,52 @@
+longer workshops - VTO
+---
+
+This initiative is for organizing longer workshops or coaching sessions that will need that coaches have longer availability thanks to VTO (Volunteering Time Off) or equivalent from their company.
+
+#  Friday afternoon workshop,
+
+A quick poll on the #barcelona-chapter slack channel gave as best choices for students a Friday afternoon workshop.
+We will try with this format and see how it goes.
+
+# Todo list
+
+* [ ] describe the new [event](#event-description)
+* [ ] contact some companies to see if they are interested in VTO or similar.
+* [ ] confirm interest & availability  of students
+* [ ] confirm interest & availability of coaches
+* organize the first workshop:
+ * [ ] find a host
+ * [ ] find a sponsor
+ * [ ] fix a date
+
+
+# Event description
+
+A special codebar workshop that last 4 hours on a Friday afternoon where the coach and student has been paired in advance and some
+
+Options to validate:
+
+* pairing in advance?
+* some preparation from students?
+* some preparation from coaches?
+* a short presentation at the end?
+* a short presentation at the beginning?
+* coffee break or lightning talks breaks? byt the coaches? students? others? hosts? sponsors?
+* how to measure the success, just students? coaches?
+* strict eligibility criteria
+
+
+# promoting VTO at companies
+
+## why VTO
+
+* promoting companies values
+* make workforce involved in companies values
+* make workforce happy because they act
+
+## why codebar
+
+* promoting diversity in tech
+* codebar format is:
+ * effective, we have various success stories
+ * coache learn too essential soft skills

--- a/processes/initiatives/longer-workshops_VTO/README.md
+++ b/processes/initiatives/longer-workshops_VTO/README.md
@@ -8,9 +8,13 @@ This initiative is for organizing longer workshops or coaching sessions that wil
 A quick poll on the #barcelona-chapter slack channel gave as best choices for students a Friday afternoon workshop.
 We will try with this format and see how it goes.
 
+# Event description
+
+See [Event-Description.md](Event-Description.md)
+
 # Todo list
 
-* [ ] describe the new [event](#event-description)
+* [x] describe the new [event](event-description.md)
 * [ ] contact some companies to see if they are interested in VTO or similar.
 * [ ] confirm interest & availability  of students
 * [ ] confirm interest & availability of coaches
@@ -20,21 +24,48 @@ We will try with this format and see how it goes.
  * [ ] fix a date
 
 
-# Event description
+---
 
-A special codebar workshop that last 4 hours on a Friday afternoon where the coach and student has been paired in advance and some
+# Quick slack poll Results
 
-Options to validate:
+ __daverick 20 oct. à 12 h 42__
 
-* pairing in advance?
-* some preparation from students?
-* some preparation from coaches?
-* a short presentation at the end?
-* a short presentation at the beginning?
-* coffee break or lightning talks breaks? byt the coaches? students? others? hosts? sponsors?
-* how to measure the success, just students? coaches?
-* strict eligibility criteria
+ Hi tod@s,
+ Just a quick pool for students to see if you are interested in longer codebar workshop for next year.
+ ¿Would you like to have and be able to attend a longer codebar workshop?
+ * ⛔ No
+ * 🍰 yes in the afternoon
+ * ☕ yes in the morning
+ * 🎂 yes all day long
+ * 5️⃣ yea all week long
+ Please choose all the possible choices you agree and do not hesitate to add your comments or suggestions.
 
+ Results:
+
+ |Choice|Votes|Voters|
+ |---|---|---|
+ |⛔ No|0||
+ |🍰 yes in the afternoon|5|Henriette, Alba, Stefi, Klara, Robby  |
+ |☕ yes in the morning|2|Henriette, Robby|
+ |🎂 yes all day long|2|Henriette, Robby|
+ |5️⃣ yea all week long|3|Henriette, Alba, Robby|
+
+
+---
+
+# Working Material:
+
+|Options |Pros|Cons|
+|---|---|---|
+|pairing in advance|better fit </br> enable preparation |organization + dificult </br> no show|
+|some preparation from students?|better engagement|time to do it|
+|some preparation from coaches?|better engagement|time to do it|
+|a short presentation at the end for each student?|completion feeling <br> emulation|less time  for learning <br>|
+|a short presentation at the beginning?|emulation <br> codebar way||
+|coffee break or lightning talks breaks?<br> by the coaches?<br> students?<br> others?<br> hosts?<br> sponsors?|||
+
+
+how to measure the success, just students?  coaches?
 
 # promoting VTO at companies
 
@@ -49,4 +80,4 @@ Options to validate:
 * promoting diversity in tech
 * codebar format is:
  * effective, we have various success stories
- * coache learn too essential soft skills
+ * coach learnes essential soft skills


### PR DESCRIPTION
This initiative is for organizing longer workshops or coaching sessions that will need that coaches have longer availability thanks to VTO (Volunteering Time Off) or equivalent from their company.

# Todo list

* [x] describe the new [event](event-description.md)
* [ ] contact some companies to see if they are interested in VTO or similar.
* [ ] confirm interest & availability  of students
* [ ] confirm interest & availability of coaches
* organize the first workshop:
 * [ ] find a host
 * [ ] find a sponsor
 * [ ] fix a date